### PR TITLE
Don't overwrite thunderstore manifest.json dependencies array

### DIFF
--- a/create_thunderstore_package.py
+++ b/create_thunderstore_package.py
@@ -68,6 +68,7 @@ def update_manifest(path: Path):
     print(f"Updating manifest at '{path}'...")
     manifest = get_package_manifest();
     del manifest["name"]
+    del manifest["dependencies"]
 
     current_manifest: dict[str, str] = json.loads(path.read_text());
     current_manifest.update(manifest)


### PR DESCRIPTION
I realized I broke this when quickbottles was missing the KV dependency. It is unfortunate that the `mod.toml` dependencies array doesn't map to thunderstore dependencies, else we could've used that.